### PR TITLE
Fixes for rails 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+### 0.0.9 (Janury 9, 2014)
+
+* [#11](https://github.com/slowjack2k/activerecord_to_poro/pull/11): Fixes for Rails 4.2 - [@slowjack2k](https://github.com/slowjack2k).

--- a/activerecord_to_poro.gemspec
+++ b/activerecord_to_poro.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'pg'
   # spec.add_development_dependency 'activerecord', '4.0.2'
   spec.add_development_dependency 'activerecord', '4.2.0'
   spec.add_development_dependency 'database_cleaner'

--- a/activerecord_to_poro.gemspec
+++ b/activerecord_to_poro.gemspec
@@ -26,7 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'activerecord', '4.0.2'
+  # spec.add_development_dependency 'activerecord', '4.0.2'
+  spec.add_development_dependency 'activerecord', '4.2.0'
   spec.add_development_dependency 'database_cleaner'
 
 

--- a/lib/activerecord_to_poro/mapper_extension.rb
+++ b/lib/activerecord_to_poro/mapper_extension.rb
@@ -44,14 +44,17 @@ module ActiverecordToPoro
     module_function
 
     def is_an_ar_collection?(ar_class, association_name)
-      (ar_class.reflections[association_name] &&
-       ar_class.reflections[association_name].collection?)
+      ref = reflection_for_association(ar_class, association_name)
+      (ref && ref.collection?)
     end
 
     def is_an_has_many_through(ar_class, association_name)
-      ar_class.reflections[association_name] &&
-      ar_class.reflections[association_name].macro == :has_many &&
-      ar_class.reflections[association_name].options.has_key?(:through)
+      ref = reflection_for_association(ar_class, association_name)
+      ref && ref.macro == :has_many && ref.options.has_key?(:through)
+    end
+
+    def reflection_for_association(ar_class, association_name)
+      ar_class.reflections[association_name.to_sym] || ar_class.reflections[association_name.to_s]
     end
 
   end

--- a/lib/activerecord_to_poro/metadata_enabled_ar.rb
+++ b/lib/activerecord_to_poro/metadata_enabled_ar.rb
@@ -14,7 +14,6 @@ module ActiverecordToPoro
     end
 
     def _update_poro_metadata
-
       _referenced_poros.each do |entity|
         entity._set_metadata_from_ar = self if entity.respond_to? :_set_metadata_from_ar=
 
@@ -39,7 +38,7 @@ module ActiverecordToPoro
 
         record.tap do |new_obj|
 
-          new_obj.attributes = attrs
+          new_obj.attributes = attrs || {}
 
           _patch_has_many_members(attrs, new_obj) unless new_obj.new_record?
         end
@@ -77,7 +76,7 @@ module ActiverecordToPoro
       end
 
       def _extract_metadata!(attrs)
-        metadata = (attrs || {}).delete(:_set_metadata_to_ar) { |*| Metadata.new }
+        metadata = (attrs || {}).delete(:_set_metadata_to_ar){ |*| Metadata.new }
         metadata.for_ar_class(self.name)
       end
 

--- a/lib/activerecord_to_poro/version.rb
+++ b/lib/activerecord_to_poro/version.rb
@@ -1,3 +1,3 @@
 module ActiverecordToPoro
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/spec/ar_spec_helper.rb
+++ b/spec/ar_spec_helper.rb
@@ -1,18 +1,28 @@
 require 'active_record'
-require 'database_cleaner'
 
 db_dir = File.join(File.expand_path(__dir__ ), "ar_support/db/")
 # ENV['DATABASE_URL']="sqlite3://localhost/:memory:?pool=5&timeout=5000"
 
+con_settings = {
+    pool: 5,
+    timeout: 5000,
+    database: ":memory:",
+    adapter: "sqlite3"
+}
 
+# con_settings = {
+#     adapter: 'postgresql',
+#     encoding: 'utf8',
+#     pool: 5,
+#     host: 'localhost',
+#     port: 5000,
+#     database: 'poro_test'
+# }
 
-ActiveRecord::Base.establish_connection({
-                                            pool: 5,
-                                            timeout: 5000,
-                                            database: ":memory:",
-                                            adapter: "sqlite3"
-                                        })
+require 'database_cleaner'
 
+ActiveRecord::Base.logger = Logger.new(STDOUT)
+ActiveRecord::Base.establish_connection(con_settings)
 ActiveRecord::Migrator.migrate "#{db_dir}/migrate"
 
 Dir[File.join(File.expand_path(__dir__ ), "ar_support/models/**/*.rb")].each { |f| require f }
@@ -20,8 +30,8 @@ Dir[File.join(File.expand_path(__dir__ ), "ar_support/models/**/*.rb")].each { |
 RSpec.configure do |config|
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.strategy = :truncation, {:except => %w[schema_migrations public.schema_migrations]}
+    DatabaseCleaner.clean_with(:truncation, {:except => %w[schema_migrations public.schema_migrations]})
   end
 
   config.before(:each) do

--- a/spec/ar_support/db/migrate/20140127093447_create_my_ar_class.rb
+++ b/spec/ar_support/db/migrate/20140127093447_create_my_ar_class.rb
@@ -4,30 +4,30 @@ class CreateMyArClass < ActiveRecord::Migration
       t.string :name
       t.string :email
       t.integer :salutation_id
-      t.integer :lock_version
+      t.integer :lock_version, default: 0
     end
 
     create_table :roles do |t|
       t.string  :name
       t.integer :user_id
-      t.integer :lock_version
+      t.integer :lock_version, default: 0
     end
 
     create_table :permissions do |t|
       t.string  :name
       t.integer :role_id
-      t.integer :lock_version
+      t.integer :lock_version, default: 0
     end
 
     create_table :salutations do |t|
       t.string  :name
-      t.integer :lock_version
+      t.integer :lock_version, default: 0
     end
 
     create_table :addresses do |t|
       t.string  :street
       t.integer :user_id
-      t.integer :lock_version
+      t.integer :lock_version, default: 0
     end
   end
 end

--- a/spec/ar_support/models/address.rb
+++ b/spec/ar_support/models/address.rb
@@ -1,3 +1,3 @@
 class Address < ActiveRecord::Base
-  belongs_to :user, autosave: true
+  belongs_to :user
 end

--- a/spec/ar_support/models/permission.rb
+++ b/spec/ar_support/models/permission.rb
@@ -1,3 +1,3 @@
 class Permission < ActiveRecord::Base
-  belongs_to :role, autosave: true
+  belongs_to :role
 end

--- a/spec/ar_support/models/role.rb
+++ b/spec/ar_support/models/role.rb
@@ -1,4 +1,4 @@
 class Role < ActiveRecord::Base
   has_many :permissions, autosave: true
-  belongs_to :user, autosave: true
+  belongs_to :user
 end

--- a/spec/ar_support/models/user.rb
+++ b/spec/ar_support/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   has_many :roles, autosave: true
   has_many :permissions, through: :roles, autosave: true
 
-  belongs_to :salutation, autosave: true
+  belongs_to :salutation
   has_one :address, autosave: true
 
 


### PR DESCRIPTION
Rails 4.2 changed the following:
- Relations-Array use String of keys instead of symbols
- AR-Object.attributes = <value> don't accepet nil any more
- lock_version needs to have a default value on db layer
